### PR TITLE
[FixBug] CocoDebugTabBarController exit bug

### DIFF
--- a/Sources/Window/CocoaDebugTabBarController.swift
+++ b/Sources/Window/CocoaDebugTabBarController.swift
@@ -97,6 +97,7 @@ class CocoaDebugTabBarController: UITabBarController {
     //MARK: - target action
     @objc func exit() {
         dismiss(animated: true, completion: nil)
+        _WindowHelper.shared.sendBackKeyWindow()
     }
     
     //MARK: - show more than 5 tabs by CocoaDebug


### PR DESCRIPTION
DebugViewController - last tab - Update AB - AlertController 弹出键盘后，UIViewController.top() 取值为 CocoDebugViewController，导致消息 - 点击 Deeplink 弹出的页面无法响应手势